### PR TITLE
feat: global ledger version & example runner - 2

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,9 @@ pnpm install
 # Pool information
 pnpm examples views
 
+# Historical balance
+pnpm examples historical-balance
+
 # Token prices
 pnpm examples user-actions
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,10 +8,7 @@
   "license": "MIT",
   "keywords": ["moar", "market", "sdk", "example", "defi", "aptos"],
   "scripts": {
-    "start": "tsx src/index.ts",
-    "dev": "tsx --watch src/index.ts",
-    "views": "tsx src/views.ts",
-    "user-actions": "tsx src/user-actions.ts",
+    "example": "tsx scripts/run-example.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --fix --cache"

--- a/examples/scripts/run-example.ts
+++ b/examples/scripts/run-example.ts
@@ -1,0 +1,45 @@
+import { spawn } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+const EXAMPLES_DIR = resolve('src')
+const fileArg = process.argv[2]
+
+function printUsageAndExit() {
+  const files = readdirSync(EXAMPLES_DIR)
+    .filter(f => f.endsWith('.ts'))
+    .map(f => f.replace(/\.ts$/, ''))
+
+  console.info(`ℹ  Please provide a valid example file name from /examples/src/.
+
+Usage:
+  pnpm examples <file>
+
+Examples:
+  pnpm examples views
+  pnpm examples user-actions
+  pnpm examples historical-balance
+
+Available files:
+${files.map(f => `  - ${f}`).join('\n')}
+`)
+  process.exit(1)
+}
+
+if (!fileArg) {
+  printUsageAndExit()
+}
+
+const fileName = fileArg.endsWith('.ts') ? fileArg : `${fileArg}.ts`
+const fullPath = resolve(EXAMPLES_DIR, fileName)
+
+if (!existsSync(fullPath)) {
+  console.error(`❌ File not found: src/${fileName}\n`)
+  printUsageAndExit()
+}
+
+spawn('tsx', [fullPath], {
+  stdio: 'inherit',
+  cwd: process.cwd(),
+})

--- a/examples/src/historical-balance.ts
+++ b/examples/src/historical-balance.ts
@@ -1,0 +1,35 @@
+import { fetchFungibleBalance, useAptos } from '@moar-market/sdk'
+
+async function main() {
+  const aptos = useAptos()
+
+  const userAddress = '0xd03d34771b9d22c94b9ed15f401240bc323f69b24da2f7d11de0e52a806978b9'
+  const aptosFA = '0xa'
+
+  const ledgerVersion = 3151821422 // historical balance at this ledger version
+
+  const [currentBalance, { ledger_version: latestLedgerVersion }] = await Promise.all([
+    fetchFungibleBalance(userAddress, aptosFA),
+    aptos.getLedgerInfo(),
+  ])
+
+  // this sets the global ledger version for all future calls after this even outside of this function in same runtime
+  aptos.setLedgerVersion?.(ledgerVersion)
+  const historicalBalances = await fetchFungibleBalance(userAddress, aptosFA)
+
+  console.log({
+    currentBalance: {
+      amount: Number(currentBalance) / 1e8,
+      ledgerVersion: Number(latestLedgerVersion),
+    },
+    historicalBalances: {
+      amount: Number(historicalBalances) / 1e8,
+      ledgerVersion: aptos.getLedgerVersion?.(),
+    },
+  })
+
+  // this resets the global ledger version for all future calls after this even outside of this function in same runtime
+  aptos.setLedgerVersion?.(undefined)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sdk": "pnpm --filter @moar-market/sdk",
     "utils": "pnpm --filter @moar-market/utils",
     "composer": "pnpm --filter @moar-market/composer",
-    "examples": "pnpm --filter @moar-market/examples",
+    "examples": "pnpm --filter @moar-market/examples run example",
     "all": "pnpm -r",
     "build": "pnpm all build",
     "dev": "pnpm all dev",

--- a/packages/sdk/src/clients/aptos.ts
+++ b/packages/sdk/src/clients/aptos.ts
@@ -1,8 +1,55 @@
-import type { AptosSettings, ClientConfig, Network } from '@aptos-labs/ts-sdk'
+import type {
+  AccountAddressInput,
+  AptosSettings,
+  ClientConfig,
+  InputViewFunctionData,
+  LedgerVersionArg,
+  MoveStructId,
+  MoveValue,
+  Network,
+} from '@aptos-labs/ts-sdk'
 import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk'
 import { useChainConfig } from './../config'
 
+declare module '@aptos-labs/ts-sdk' {
+  interface Aptos {
+    /**
+     * Sets the global ledger version for all future view/getAccountResource calls.
+     * This is a global setting and will be used only when you want to view data at a specific ledger version.
+     * To reset to the latest version, set the value to undefined.
+     *
+     * @example
+     * const aptos = useAptos();
+     * aptos.setLedgerVersion(3151821422); // sets global ledger version
+     * const balance = await fetchFungibleBalance(userAddress, aptosFA);
+     * aptos.setLedgerVersion(undefined); // resets to latest version
+     */
+    setLedgerVersion?: (value: number | undefined) => void
+    /**
+     * Gets the global ledger version used for all the calls which does not set explicit ledger version on
+     * view/getAccountResource calls.
+     * To reset to the latest version, call setLedgerVersion with undefined.
+     *
+     * @example
+     * const aptos = useAptos();
+     * const ledgerVersion = aptos.getLedgerVersion();
+     */
+    getLedgerVersion?: () => number | undefined
+  }
+}
+
 let aptosInstance: Aptos
+let ledgerVersion: number | undefined
+let originalAptosView: typeof Aptos.prototype.view
+let originalAptosGetAccountResource: typeof Aptos.prototype.getAccountResource
+
+function getLedgerVersionArg(options?: LedgerVersionArg): LedgerVersionArg {
+  const ledgerVersionToUse = options?.ledgerVersion !== undefined
+    ? options.ledgerVersion
+    : ledgerVersion
+
+  return { ledgerVersion: ledgerVersionToUse }
+}
 
 export function useAptos(): Aptos {
   const chain = useChainConfig()
@@ -10,7 +57,38 @@ export function useAptos(): Aptos {
   // Using RPC URL for comparison since chainId is async
   if (!aptosInstance || chain.rpc !== aptosInstance.config.fullnode) {
     aptosInstance = new Aptos(useAptosConfig())
+
+    // override view to use instance level ledger version
+    originalAptosView = aptosInstance.view.bind(aptosInstance)
+    aptosInstance.view = async function <T extends Array<MoveValue>>(args: {
+      payload: InputViewFunctionData
+      options?: LedgerVersionArg
+    }): Promise<T> {
+      return await originalAptosView({
+        payload: args.payload,
+        options: getLedgerVersionArg(args.options),
+      })
+    }
+
+    originalAptosGetAccountResource = aptosInstance.getAccountResource.bind(aptosInstance)
+    aptosInstance.getAccountResource = async function <T extends object = any>(args: {
+      accountAddress: AccountAddressInput
+      resourceType: MoveStructId
+      options?: LedgerVersionArg
+    }): Promise<T> {
+      return await originalAptosGetAccountResource({
+        ...args,
+        options: getLedgerVersionArg(args.options),
+      })
+    }
+
+    // add helper for ledger version management
+    Object.assign(aptosInstance, {
+      setLedgerVersion: (value: number | undefined) => { ledgerVersion = value },
+      getLedgerVersion: () => ledgerVersion,
+    })
   }
+
   return aptosInstance
 }
 

--- a/packages/sdk/src/clients/surf.ts
+++ b/packages/sdk/src/clients/surf.ts
@@ -1,72 +1,16 @@
-import type { LedgerVersionArg, MoveStructId, MoveValue } from '@aptos-labs/ts-sdk'
-import type { ViewPayload } from '@thalalabs/surf'
-import type { Address } from '../types'
 import { createSurfClient } from '@thalalabs/surf'
 import { useChainConfig } from './../config'
 import { useAptos } from './aptos'
 
-let ledgerVersion: number | undefined
 let surfClient: ReturnType<typeof createSurfClient>
 let chainId: number
 
-// Define an interface for the return type
-export interface SurfClientInterface {
-  view: <TReturn extends MoveValue[]>(args: {
-    payload: ViewPayload<TReturn>
-    options?: LedgerVersionArg
-  }) => Promise<TReturn>
-  getAccountResource: (args: {
-    accountAddress: Address
-    resourceType: MoveStructId
-    options?: LedgerVersionArg
-  }) => Promise<any>
-  simulateTransaction: ReturnType<typeof createSurfClient>['simulateTransaction']
-  fetchABI: ReturnType<typeof createSurfClient>['fetchABI']
-  useABI: ReturnType<typeof createSurfClient>['useABI']
-  submitTransaction: ReturnType<typeof createSurfClient>['submitTransaction']
-  getLedgerVersion: () => number | undefined
-  setLedgerVersion: (value: number | undefined) => void
-}
-
-export function useSurfClient(): SurfClientInterface {
+export function useSurfClient() {
   // after changing the chain in config at runtime, we need to recreate the surf client
   if (!surfClient || chainId !== useChainConfig().chainId) {
     chainId = useChainConfig().chainId
     surfClient = createSurfClient(useAptos())
   }
 
-  async function view<TReturn extends MoveValue[]>(args: {
-    payload: ViewPayload<TReturn>
-    options?: LedgerVersionArg
-  }): Promise<TReturn> {
-    return await surfClient.view({
-      payload: args.payload,
-      options: args.options ? args.options : { ledgerVersion },
-    })
-  }
-
-  async function getAccountResource(args: {
-    accountAddress: Address
-    resourceType: MoveStructId
-    options?: LedgerVersionArg
-  }) {
-    return await useAptos().getAccountResource({
-      accountAddress: args.accountAddress,
-      resourceType: args.resourceType,
-      options: args.options ? args.options : { ledgerVersion },
-    })
-  }
-
-  return {
-    view, // view function with ledger version
-    getAccountResource, // get account resource with ledger version
-
-    simulateTransaction: surfClient.simulateTransaction,
-    fetchABI: surfClient.fetchABI,
-    useABI: surfClient.useABI,
-    submitTransaction: surfClient.submitTransaction,
-
-    getLedgerVersion: () => ledgerVersion,
-    setLedgerVersion: (value: number | undefined) => { ledgerVersion = value },
-  }
+  return surfClient
 }


### PR DESCRIPTION
## ✨ Features

### 🔹 Global Ledger Version Support

* Added support for globally overriding the ledger version used in `.view()` and `.getAccountResource()` calls.
* You can now set a custom ledger version like this:

```ts
const aptos = useAptos()
aptos.setLedgerVersion?.(3151821422) // Use this ledger version for all future view/resource reads
```

* To reset and use the latest version again:

```ts
aptos.setLedgerVersion?.(undefined)
```

* Also available:

```ts
aptos.getLedgerVersion?.() // Returns the current global ledger version (if set)
```

---

### 🔹 Example Runner CLI

* Added a new script to easily run example files from `examples/src/`.

Run any example like this:

```bash
pnpm examples user-actions
# or
pnpm examples user-actions.ts
# or
pnpm examples inner-dir/action1
```

* If no file is provided or the file doesn't exist, the CLI will:

  * Show usage help
  * List all available `.ts` files in `examples/src/` & `examples/src/subdir

---